### PR TITLE
add syntax highlighting using pygments

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -15,3 +15,85 @@ header, nav, section, article, footer {
  * those from the theme
  */
 section hr, article hr {}
+
+code {
+  font-family: "Lucida Console", Monaco, monospace;
+  font-size: 80%;
+  color: #555;
+  padding: .2em .4em;
+  border-radius: 2px
+}
+
+pre {
+  border: 1px solid #ddd;
+  display: block;
+  margin: 2em 0;
+  padding: .625rem;
+  line-height: 1.2
+}
+
+code, pre {
+  overflow-x: auto;
+}
+
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #999988; font-style: italic }
+.highlight .err { color: #a61717; background-color: #e3d2d2 }
+.highlight .k { color: #000000; font-weight: bold }
+.highlight .o { color: #000000; font-weight: bold }
+.highlight .cm { color: #999988; font-style: italic }
+.highlight .cp { color: #999999; font-weight: bold; font-style: italic }
+.highlight .c1 { color: #999988; font-style: italic }
+.highlight .cs { color: #999999; font-weight: bold; font-style: italic }
+.highlight .gd { color: #000000; background-color: #ffdddd }
+.highlight .ge { color: #000000; font-style: italic }
+.highlight .gr { color: #aa0000 }
+.highlight .gh { color: #999999 }
+.highlight .gi { color: #000000; background-color: #ddffdd }
+.highlight .go { color: #888888 }
+.highlight .gp { color: #555555 }
+.highlight .gs { font-weight: bold }
+.highlight .gu { color: #aaaaaa }
+.highlight .gt { color: #aa0000 }
+.highlight .kc { color: #000000; font-weight: bold }
+.highlight .kd { color: #000000; font-weight: bold }
+.highlight .kn { color: #000000; font-weight: bold }
+.highlight .kp { color: #000000; font-weight: bold }
+.highlight .kr { color: #000000; font-weight: bold }
+.highlight .kt { color: #445588; font-weight: bold }
+.highlight .m { color: #009999 }
+.highlight .s { color: #d01040 }
+.highlight .na { color: #008080 }
+.highlight .nb { color: #0086B3 }
+.highlight .nc { color: #445588; font-weight: bold }
+.highlight .no { color: #008080 }
+.highlight .nd { color: #3c5d5d; font-weight: bold }
+.highlight .ni { color: #800080 }
+.highlight .ne { color: #990000; font-weight: bold }
+.highlight .nf { color: #990000; font-weight: bold }
+.highlight .nl { color: #990000; font-weight: bold }
+.highlight .nn { color: #555555 }
+.highlight .nt { color: #000080 }
+.highlight .nv { color: #008080 }
+.highlight .ow { color: #000000; font-weight: bold }
+.highlight .w { color: #bbbbbb }
+.highlight .mf { color: #009999 }
+.highlight .mh { color: #009999 }
+.highlight .mi { color: #009999 }
+.highlight .mo { color: #009999 }
+.highlight .sb { color: #d01040 }
+.highlight .sc { color: #d01040 }
+.highlight .sd { color: #d01040 }
+.highlight .s2 { color: #d01040 }
+.highlight .se { color: #d01040 }
+.highlight .sh { color: #d01040 }
+.highlight .si { color: #d01040 }
+.highlight .sx { color: #d01040 }
+.highlight .sr { color: #009926 }
+.highlight .s1 { color: #d01040 }
+.highlight .ss { color: #990073 }
+.highlight .bp { color: #999999 }
+.highlight .vc { color: #008080 }
+.highlight .vg { color: #008080 }
+.highlight .vi { color: #008080 }
+.highlight .il { color: #009999 }


### PR DESCRIPTION
This solution uses the integration of Hugo with [pygments](https://gohugo.io/content-management/syntax-highlighting) which is a js-free solution.

You need to configure this on `config.toml`:
```toml
pygmentsCodeFences = true
pygmentsUseClasses = true
```

Preview:

![image](https://user-images.githubusercontent.com/10618352/46692663-43794780-cbde-11e8-9f93-50f25ca316ce.png)